### PR TITLE
Try single quotes to fix workflow

### DIFF
--- a/.github/workflows/publish-main-android.yml
+++ b/.github/workflows/publish-main-android.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Push to CDN
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --exclude "*" --include "/app/android-tds.json"
+          args: --acl public-read --follow-symlinks --exclude '*' --include '/app/android-tds.json'
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Attempting fix by changing arg quotes to single from double based on this [note](https://github.com/jakejarvis/s3-sync-action#the-following-example-includes-optimal-defaults-for-a-public-static-website).