### PR TITLE
[Backup option] Try with different action

### DIFF
--- a/.github/workflows/publish-main-android.yml
+++ b/.github/workflows/publish-main-android.yml
@@ -1,28 +1,26 @@
 name: Update production android apptp blocklist
-
-on:
+on: 
   push:
     branches:
       - main
 
 jobs:
-  build-and-deploy:
+  deploy:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - uses: actions/setup-node@v2.1.2
+      - name: Checkout 
+      - uses: actions/checkout@v2
+      
+      - name: Upload file to CDN
+      - uses: a-sync/s3-uploader@v2
         with:
-          node-version: "14"
-
-      - name: Push to CDN
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --exclude '*' --include '/android-tds.json'
+          args: --acl public-read
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: "app"
+          AWS_REGION: 'eu-central-1'
+          FILE: ./app/android-tds.json
           DEST_DIR: "trackerblocking/appTP/2.0"
+        

--- a/.github/workflows/publish-main-android.yml
+++ b/.github/workflows/publish-main-android.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout 
+      - name: Checkout
         uses: actions/checkout@v2
       
       - name: Upload file to CDN
@@ -24,4 +24,4 @@ jobs:
           AWS_REGION: 'eu-central-1'
           FILE: ./app/android-tds.json
           DEST_DIR: "trackerblocking/appTP/2.0"
-        
+          

--- a/.github/workflows/publish-main-android.yml
+++ b/.github/workflows/publish-main-android.yml
@@ -1,6 +1,6 @@
 name: Update production android apptp blocklist
 
-on: 
+on:
   push:
     branches:
       - main
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout 
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
       
       - name: Upload file to CDN
-      - uses: a-sync/s3-uploader@v2
+        uses: a-sync/s3-uploader@v2
         with:
           args: --acl public-read
         env:

--- a/.github/workflows/publish-main-android.yml
+++ b/.github/workflows/publish-main-android.yml
@@ -1,4 +1,5 @@
 name: Update production android apptp blocklist
+
 on: 
   push:
     branches:


### PR DESCRIPTION
Adding [a follow-up option](https://github.com/marketplace/actions/s3-uploader) if we can't find a workaround for the original sync action. This project was more recently updated and uses `cp` rather than `sync`, so maybe we can avoid some issues depending on what's up with the original.