### PR TITLE
Validation for blocking decisions of subdomains and their parent domains

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,6 +1,6 @@
 # DuckDuckGo's App Tracker Blocklist
 
-The app tracker blocklist is used by [DuckDuckGo App Tracking Protection](https://spreadprivacy.com/introducing-app-tracking-protection/), currently available in beta on Android only.
+The app tracker blocklist is used by [DuckDuckGo App Tracking Protection](https://spreadprivacy.com/app-tracking-protection-open-beta/), currently available in beta on Android only.
 We build this list by interacting with popular Android apps and identifying common third-party requests that are sharing personal data, unique identifiers, or other information that could be used for fingerprinting.
 In the future, we plan to make the data and the tools used for data collection public.
 Questions or issues with tracker blocking in DuckDuckGo apps and extensions should be reported in the [Privacy Configuration](https://github.com/duckduckgo/privacy-configuration).
@@ -8,7 +8,7 @@ Questions or issues with tracker blocking in DuckDuckGo apps and extensions shou
 ## Questions
 
 - **Where are the blocklists?**
-  - [android-tds.json](android-tds.json) is the blocklist used by [DuckDuckGo App Tracking Protection](https://spreadprivacy.com/introducing-app-tracking-protection/) beta on Android.
+  - [android-tds.json](android-tds.json) is the blocklist used by [DuckDuckGo App Tracking Protection](https://spreadprivacy.com/app-tracking-protection-open-beta/) beta on Android.
 - **Where can I find the code that generates the blocklists?** The code to generate blocklists is not yet open source but coming soon.
 - **Are there any exceptions that should be applied to the blocklist?** 
 We exclude certain apps from protection if we find that they do not work with VPNs or rely on tracking domains to function. 

--- a/tests/schemas/android.json
+++ b/tests/schemas/android.json
@@ -18,7 +18,7 @@
                             "required": ["name", "displayName"],
                             "additionalProperties": false
                         },
-                        "default": { "type": "string" }
+                        "default": { "enum": ["block", "ignore"] }
                     },
                     "required": ["owner", "default"],
                     "additionalProperties": false

--- a/tests/schemas/android.json
+++ b/tests/schemas/android.json
@@ -1,0 +1,51 @@
+{
+    "type": "object",
+    "properties": {
+        "readme": {"type": "string"},
+        "version": {"type": "integer"},
+        "trackers": {
+            "type": "object",
+            "patternProperties": {
+                "^.+\\..+$": {
+                    "type": "object",
+                    "properties": {
+                        "owner": {
+                            "type": "object",
+                            "properties": {
+                                "name": { "type": "string" },
+                                "displayName": { "type": "string" }
+                            },
+                            "required": ["name", "displayName"],
+                            "additionalProperties": false
+                        },
+                        "default": { "type": "string" }
+                    },
+                    "required": ["owner", "default"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "packageNames": {
+            "type": "object",
+            "patternProperties": {
+                "^.+\\..+$": { "type": "string" }
+            }
+        },
+        "entities": {
+            "type": "object",
+            "patternProperties": {
+                "^.{2,}$": {
+                    "type": "object",
+                    "properties": {
+                        "score": { "type": "integer" },
+                        "signals": { "type": "array" }
+                    },
+                    "required": ["score", "signals"],
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    "required": ["readme", "version", "trackers", "packageNames", "entities"],
+    "additionalProperties": false
+}

--- a/tests/validate-android-tds.js
+++ b/tests/validate-android-tds.js
@@ -3,71 +3,51 @@ const fs = require("fs")
 const ajv = new Ajv({ allErrors: true })
 const expect = require('chai').expect
 
-
-const schema = {
-    type: "object",
-    properties: {
-        readme: {type: "string"},
-        version: {type: "integer"},
-        trackers: {
-            type: "object",
-            patternProperties: {
-                "^.+\..+$": {type: "object",
-                    properties: {
-                        owner: {type: "object",
-                            properties: {
-                                name: { type: "string" },
-                                displayName: { type: "string" },
-                            },
-                            required: ["name", "displayName"],
-                            additionalProperties: false,
-                        },
-                        default: { type: "string" },
-                    },
-                    required: ["owner", "default"],
-                    additionalProperties: false,
-                },
-                
-            },
-        },
-        packageNames: {
-            type: "object",
-            patternProperties: {
-                "^.+\..+$": {type: "string"},
-            },
-        },
-        entities: {
-            type: "object",
-            patternProperties: {
-                "^.{2,}$": {
-                    type: "object",
-                    properties: {
-                        score: { type: "integer" },
-                        signals: { type: "array" },
-                    },
-                    required: ["score", "signals"],
-                    additionalProperties: false,
-                },
-            },
-        },
-    },
-    required: ["readme", "version", "trackers", "packageNames", "entities"],
-    additionalProperties: false,
-}
-
 function formatErrors (errors) {
     if (!Array.isArray(errors)) {
         return ''
     }
 
     return errors.map(item => `${item.instancePath}: ${item.message}`).join(', ')
+}  
+
+function isSubdomain(host1, host2) {
+    var tokens1 = host1.split(".");
+    var tokens2 = host2.split(".");
+    if (tokens1.length <= tokens2.length) {
+        return false;
+    }
+
+    var idx1 = tokens1.length - 1;
+    for (var idx2 = tokens2.length - 1; idx2 >= 0; idx2--) {
+        if (tokens2[idx2] !== tokens1[idx1]) {
+            return false;
+        }
+        idx1 -= 1;
+    }
+
+    return true;
 }
 
+const schema = JSON.parse(fs.readFileSync('./tests/schemas/android.json'))
 const validate = ajv.compile(schema)
 const list = JSON.parse(fs.readFileSync("app/android-tds.json"))
 
 describe('validate android-tds', () => {
     it('should have a valid schema', () => {
         expect(validate(list)).to.be.equal(true, formatErrors(validate.errors))
+    })
+    it('should have not differing decisions between domains and their sub-domains', () => {
+        // Temporary check until we figure out a better structure for our list (see https://app.asana.com/0/1164076839969833/1204452354987508/f)
+        var hostnames = Object.keys(list['trackers']);
+        for (var i = 0; i < hostnames.length; i++) {
+            for (var j = i + 1; j < hostnames.length; j++) {
+                var host1 = hostnames[i];
+                var host2 = hostnames[j];
+                if (isSubdomain(host1, host2) && list['trackers'][host1]['default'] === 'ignore') {
+                    expect(list['trackers'][host2]['default']).to.be.equal('ignore', host2 + ' decision differs from sub-domain ' + host1)
+                }
+            }
+        }
     })
 })


### PR DESCRIPTION
Asana task: https://app.asana.com/0/0/1204462542069469/f

**Description**:
* Validate that the list does not contain cases where the higher-level domain is set to `block` but one of its sub-domains is set to `ignore` - current AppTP implementation does not support this. Future versions will fix this.
* Incidentally: 
  * Update README to point to the latest blogpost
  * Make validation schema stricter on allowed `default` values