### PR TITLE
Bump app endpoint version to 2.1

### DIFF
--- a/.github/workflows/publish-main-android.yml
+++ b/.github/workflows/publish-main-android.yml
@@ -25,4 +25,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE_DIR: "app"
-          DEST_DIR: "trackerblocking/appTP/2.0"
+          DEST_DIR: "trackerblocking/appTP/2.1"


### PR DESCRIPTION
After fixes to Android in https://app.asana.com/0/488551667048375/1204479514332481/f, we need to bump the endpoint to keep from breaking earlier versions.