### PR TITLE
Add exception for RevenueCat API

### DIFF
--- a/app/android-tds.json
+++ b/app/android-tds.json
@@ -343,7 +343,7 @@
                 "name": "RevenueCat",
                 "displayName": "RevenueCat"
             },
-            "default": "block"
+            "default": "ignore"
         },
         "api.rlcdn.com": {
             "owner": {


### PR DESCRIPTION
**Asana task**: https://app.asana.com/0/0/1205786359852139/f

* Causing breakage with subscriptions across apps (e.g. `com.pixlr.express`, `com.vsco.cam`, `co.brainly`, `com.youmusic.magictiles`, etc.)
* See also https://github.com/duckduckgo/privacy-configuration/issues/1429