### PR TITLE
Remove Airship

### DIFF
--- a/app/android-tds.json
+++ b/app/android-tds.json
@@ -653,13 +653,6 @@
             },
             "default": "block"
         },
-        "combine.urbanairship.com": {
-            "owner": {
-                "name": "Urban Airship, Inc.",
-                "displayName": "Urban Airship"
-            },
-            "default": "block"
-        },
         "configure.rayjump.com": {
             "owner": {
                 "name": "Talent Game Box",
@@ -790,13 +783,6 @@
             "owner": {
                 "name": "33Across, Inc.",
                 "displayName": "33Across"
-            },
-            "default": "block"
-        },
-        "device-api.urbanairship.com": {
-            "owner": {
-                "name": "Urban Airship, Inc.",
-                "displayName": "Urban Airship"
             },
             "default": "block"
         },
@@ -5211,26 +5197,6 @@
                 "device_make",
                 "os_version",
                 "country",
-                "platform"
-            ]
-        },
-        "Urban Airship, Inc.": {
-            "score": 4751,
-            "signals": [
-                "gps_coordinates",
-                "email_address",
-                "neighborhood",
-                "city",
-                "unique_identifier",
-                "network_carrier",
-                "app_version",
-                "device_model",
-                "app_name",
-                "device_make",
-                "os_version",
-                "country",
-                "timezone",
-                "device_screen_density",
                 "platform"
             ]
         },


### PR DESCRIPTION
Unblock Airship as they no longer collect strong tracking signals

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-only change that updates the tracker blocklist; main impact is that Airship domains/entities will no longer be treated as trackers in this dataset.
> 
> **Overview**
> **Removes Airship from the Android TDS dataset.**
> 
> `app/android-tds.json` drops the `combine.urbanairship.com` and `device-api.urbanairship.com` tracker entries and removes the `Urban Airship, Inc.` entity classification/score, effectively unblocking Airship in this list. Also fixes the missing trailing newline at EOF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb2654c94fdd521b3b03bd9bac59d07f3f5490f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->